### PR TITLE
Start using conventional commits

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -1,0 +1,4 @@
+commitizen:
+  name: cz_conventional_commits
+  tag_format: $version
+  version: 0.0.1

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,22 @@
+name: Bump version
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  bump-version:
+    if: ${{ !startsWith(github.event.head_commit.message, 'bump:') }}
+    runs-on: ubuntu-latest
+    name: Bump version and create changelog with commitizen
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ github.token }}
+      - name: Print Version
+        run: echo Bumped to version ${{ steps.cz.outputs.version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,8 @@ repos:
     rev: 62302476d0da01515660132d76902359bed0f782
     hooks:
     - id: clang-format
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v2.18.1
+    hooks:
+    - id: commitizen
+      stages: [commit-msg]


### PR DESCRIPTION
Add a commitizen configuration and pre-commit hook to check if commit
messages follow the conventional commits specification. This should also
help to use semantic versioning.