### PR TITLE
style: fix clang-tidy configuration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,12 +13,16 @@ CheckOptions:
     value: 'true'
   - key: cppcoreguidelines-narrowing-conversions.PedanticMode
     value: 'true'
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: 'true'
   - key: google-runtime-int.UnsignedTypePrefix
     value: 'std::uint'
   - key: google-runtime-int.SignedTypePrefix
     value: 'std::int'
   - key: google-runtime-int.TypeSuffix
     value: '_t'
+  - key: hicpp-special-member-functions.AllowSoleDefaultDtor
+    value: 'true'
   - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value: 'true'
   - key: cert-dcl16-c.NewSuffixes

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '*,-abseil-*,abseil-no-namespace,-altera-struct-pack-align,-android-cloexec-fopen,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-type-vararg,-darwin-*,-fuchsia-*,fuchsia-statically-constructed-objects,fuchsia-trailing-return,-google-build-using-namespace,-google-readability-braces-around-statements,-google-readability-todo,-google-runtime-references,-hicpp-braces-around-statements,-hicpp-vararg,-llvm-header-guard,-llvmlibc-*,-modernize-use-trailing-return-type,-readability-braces-around-statements,-readability-named-parameter,-hicpp-named-parameter'
+Checks: '*,-abseil-*,abseil-no-namespace,-altera-struct-pack-align,-altera-unroll-loops,-android-cloexec-fopen,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-type-vararg,-darwin-*,-fuchsia-*,fuchsia-statically-constructed-objects,fuchsia-trailing-return,-google-build-using-namespace,-google-readability-braces-around-statements,-google-readability-todo,-google-runtime-references,-hicpp-braces-around-statements,-hicpp-vararg,-llvm-header-guard,-llvmlibc-*,-modernize-use-trailing-return-type,-readability-braces-around-statements,-readability-named-parameter,-hicpp-named-parameter'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
allow sole default destructor