### PR TITLE
ci: drop code coverage github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,24 +113,6 @@ jobs:
           GCOV: ${{ matrix.config.gcov }}
         run: poetry run gcovr
 
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
-        if: ${{ !cancelled() }}
-        with:
-          report_paths: '**/junit-reports/*.xml'
-          annotate_only: true
-          fail_on_failure: true
-
-      - name: Publish test coverage to codecov
-        if: matrix.build.type == 'Debug'
-        uses: codecov/codecov-action@v4
-        with:
-          flags: linux-${{ matrix.config.cc }}
-          name: ${{ matrix.config.name }}
-          files: coverage/cobertura.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-
   build_macos:
     name: ${{ matrix.config.name }} ${{ matrix.build.type }}
     runs-on: macos-15
@@ -210,24 +192,6 @@ jobs:
       - name: Collect test coverage
         if: matrix.build.type == 'Debug'
         run: GCOV="$(brew --prefix llvm@18)/bin/llvm-cov gcov" poetry run gcovr
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
-        if: ${{ !cancelled() }}
-        with:
-          report_paths: '**/junit-reports/*.xml'
-          annotate_only: true
-          fail_on_failure: true
-
-      - name: Publish test coverage to codecov
-        if: matrix.build.type == 'Debug'
-        uses: codecov/codecov-action@v4
-        with:
-          flags: macos-clang
-          name: ${{ matrix.config.name }}
-          files: coverage/cobertura.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
 
   build_windows:
     name: ${{ matrix.config.name }} ${{ matrix.build.type }}
@@ -316,24 +280,6 @@ jobs:
         if: matrix.build.type == 'Debug'
         run: |
           & "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe" --export_type cobertura:coverage/cobertura.xml --cover_children -- ctest --preset ${{ matrix.build.preset }}
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
-        if: ${{ !cancelled() }}
-        with:
-          report_paths: '**/junit-reports/*.xml'
-          annotate_only: true
-          fail_on_failure: true
-
-      - name: Publish test coverage to codecov
-        if: matrix.build.type == 'Debug'
-        uses: codecov/codecov-action@v4
-        with:
-          flags: windows-${{ matrix.config.cc }}
-          name: ${{ matrix.config.name }}
-          files: coverage/cobertura.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
 
   codeql:
     name: CodeQL

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # cpp-project-template
 
 [![CI](https://github.com/b1ackviking/cpp-project-template/actions/workflows/ci.yml/badge.svg)](https://github.com/b1ackviking/cpp-project-template/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/b1ackviking/cpp-project-template/branch/main/graph/badge.svg?token=FSWI6GZ1J9)](https://codecov.io/gh/b1ackviking/cpp-project-template)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com)
 
 ## About cpp-project-template
@@ -135,9 +134,3 @@ Code owners are not automatically requested to review draft pull requests.
 
 Dependabot is a GitHub bot that helps you keep dependencies up to date.
 Configure dependency scanning in the `.github/dependabot.yml` file.
-
-### Add a Codecov token
-
-If you want to use [Codecov GitHub Action](https://github.com/codecov/codecov-action/),
-you need to set a `CODECOV_TOKEN` secret from codecov.io.
-Note that it has to be accessible by Dependabot.


### PR DESCRIPTION
Stop using 3rd-party github actions for displaying test results and coverage info.